### PR TITLE
fix: restrict indexer regexp - Fixes #29

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -13,10 +13,12 @@ describe('ts-dot-prop methods', () => {
         {
           type: 'Apple',
           color: 'red',
+          color2: 'green',
         },
         {
           type: 'Mango',
           color: 'orange',
+          color2: 'yellow',
         },
       ],
     };
@@ -43,6 +45,11 @@ describe('ts-dot-prop methods', () => {
   it('should return an array of values when present', () => {
     const value: string[] = dot.get(obj, 'fruit[*].color');
     expect(value).toEqual(['red', 'orange']);
+  });
+
+  it('should return an array of values when present with digit', () => {
+    const value: string[] = dot.get(obj, 'fruit[*].color2');
+    expect(value).toEqual(['green', 'yellow']);
   });
 
   it('should return undefined when value not present', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Regex to test if a string is a valid array index key.
  */
-const indexer: RegExp = /[0-9]+/;
+const indexer: RegExp = /^[0-9]+$/;
 
 /**
  * Disallowed keys.


### PR DESCRIPTION
Fixes #29

Solve the problem where property names that include a digit (e.g. `prop1`) were failing to resolve when inside an array

__Note__ I've not contributed much publicly before so if I need to do something different please let me know