### PR TITLE
2.1.1: Paths nested object bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-dot-prop",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "TypeScript utility to transform nested objects using a dot notation path.",
   "keywords": [
     "access",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-dot-prop",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "TypeScript utility to transform nested objects using a dot notation path.",
   "keywords": [
     "access",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -8,6 +8,10 @@ describe('ts-dot-prop methods', () => {
       foo: 'bar',
       state: {
         name: 'New York',
+        people: {
+          population: 100
+        },
+        abbreviation: 'NY'
       },
       fruit: [
         {
@@ -149,7 +153,7 @@ describe('ts-dot-prop methods', () => {
    */
   it('should return an array of strings', () => {
     const value: string[] = dot.paths(obj);
-    expect(value).toEqual(['foo', 'state.name', 'fruit']);
+    expect(value).toEqual(['foo', 'state.name', 'state.people.population', 'state.abbreviation', 'fruit']);
   });
 
   it('should return an empty array', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,7 @@ function _paths(obj: object, lead: string[]): string[] {
       output = output.concat(_paths(obj[key], lead));
 
       // reset path lead for next object
-      lead = [];
+      lead.pop();
     } else {
       const path: string = lead.length ? `${lead.join('.')}.${key}` : key;
       output.push(path);


### PR DESCRIPTION
## Description

<!-- please describe the issue fixed or current behavior you are modifying / the new behavior -->

If nesting goes further than 1 level deep and there are additional properties after nesting further, the result of calling `paths(obj)` will result in an incorrect path array. Updating the logic to pop off of the lead array instead of resetting it resolves the issue at hand.

## Checklist

Please ensure your pull request fulfills the following requirements:

- [X] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md)).
- [X] Tests for any changes have been added (for bug fixes / features).
- [X] Docs have been added / updated (for bug fixes / features).

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[X] Bug.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Build related changes.
[ ] CI related changes.
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[X] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

https://github.com/justinlettau/ts-dot-prop/issues/53