### PR TITLE
justinlettau/ts-dot-prop#74 - remove should not produce sparse arrays

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -143,6 +143,11 @@ describe('ts-dot-prop methods', () => {
     expect(obj.state.name).toEqual(undefined);
   });
 
+  it('should create a dense array when romoving array value', () => {
+    dot.remove(obj, 'fruit[0]');
+    expect(obj.fruit[0].color).toEqual('orange');
+  });
+
   it('should remove array value', () => {
     dot.remove(obj, 'fruit[0].color');
     expect(obj.fruit[0].color).toEqual(undefined);

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,12 +156,12 @@ export function remove(obj: object, path: string): boolean {
 
       // todo (jbl): support wildcard [*]
 
-      if (isArray<any>(obj) && !isNaN(+key)) {
-        obj = obj.splice(+key, 1)
+      if (isArray(obj) && !isNaN(+key)) {
+        obj.splice(+key, 1);
         return true;
+      } else {
+        return delete obj[key];
       }
-
-      return delete obj[key];
     }
 
     obj = obj[key];

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,10 +153,16 @@ export function remove(obj: object, path: string): boolean {
 
     if (i === len - 1) {
       // last part in path
+
+      // todo (jbl): support wildcard [*]
+
+      if (isArray<any>(obj) && !isNaN(+key)) {
+        obj = obj.splice(+key, 1)
+        return true;
+      }
+
       return delete obj[key];
     }
-
-    // todo (jbl): support wildcard [*]
 
     obj = obj[key];
 


### PR DESCRIPTION
## Description

When `remove(obj, 'arrayProperty[0]')` is used, we use `slice()` rather than `delete` to avoid dangling undefined elements. Bug was posted in #74, fix turned out to be quite simple!

## Checklist

Please ensure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).

## Breaking Changes

Does this pull request introduce any breaking changes?

- [ ] Yes
- [x] No
